### PR TITLE
Discord: set owner to sksat

### DIFF
--- a/terraform/discord/discord.tf
+++ b/terraform/discord/discord.tf
@@ -22,6 +22,7 @@ provider "discord" {
 }
 
 resource "discord_server" "pasokonistan" {
-  name   = "パソコニスタン"
-  region = "japan"
+  name     = "パソコニスタン"
+  region   = "japan"
+  owner_id = "281041763009822720" # sksat
 }


### PR DESCRIPTION
- #2 
- アクセス不可能な Discord サーバが発生しているので，owner を @sksat に設定する
- ここの id は直接設定するしかないので，一旦直打ち（`discord_member` はサーバに紐付いているので使えない）