### PR TITLE
Discord: sksat を owner にする

### DIFF
--- a/terraform/discord/discord.tf
+++ b/terraform/discord/discord.tf
@@ -24,7 +24,7 @@ provider "discord" {
 resource "discord_server" "pasokonistan" {
   name          = "パソコニスタン"
   region        = "japan"
-  owner_id      = data.discord_member.sksat.id
+  owner_id      = "281041763009822720" # Cycle: data.discord_member.sksat.id
   icon_data_uri = data.discord_local_image.logo.data_uri
 }
 data "discord_local_image" "logo" {


### PR DESCRIPTION
- #2 
- Terraform 用の Bot がオーナーになっているので，AI の支配から解放する